### PR TITLE
Preserve horizontal scroll on date filters

### DIFF
--- a/app/javascript/controllers/preserve_scroll_controller.js
+++ b/app/javascript/controllers/preserve_scroll_controller.js
@@ -1,0 +1,25 @@
+import { Controller } from '@hotwired/stimulus'
+
+export default class extends Controller {
+
+  connect() {
+    if (!window.scrollPositions) {
+      window.scrollPositions = {};
+    }
+
+    window.addEventListener("turbo:before-render", this.preserveScroll)
+    window.addEventListener("turbo:render", this.restoreScroll)
+  }
+
+  preserveScroll () {
+    document.querySelectorAll("[data-preserve-scroll]").forEach((element) => {
+      scrollPositions[element.id] = element.scrollLeft;
+    })
+  }
+
+  restoreScroll () {
+    document.querySelectorAll("[data-preserve-scroll]").forEach((element) => {
+      element.scrollLeft = scrollPositions[element.id];
+    })
+  }
+}

--- a/app/javascript/controllers/preserve_scroll_controller.js
+++ b/app/javascript/controllers/preserve_scroll_controller.js
@@ -1,25 +1,24 @@
 import { Controller } from '@hotwired/stimulus'
 
 export default class extends Controller {
-
-  connect() {
+  connect () {
     if (!window.scrollPositions) {
-      window.scrollPositions = {};
+      window.scrollPositions = {}
     }
 
-    window.addEventListener("turbo:before-render", this.preserveScroll)
-    window.addEventListener("turbo:render", this.restoreScroll)
+    window.addEventListener('turbo:before-render', this.preserveScroll)
+    window.addEventListener('turbo:render', this.restoreScroll)
   }
 
   preserveScroll () {
-    document.querySelectorAll("[data-preserve-scroll]").forEach((element) => {
-      scrollPositions[element.id] = element.scrollLeft;
+    document.querySelectorAll('[data-preserve-scroll]').forEach((element) => {
+      window.scrollPositions[element.id] = element.scrollLeft
     })
   }
 
   restoreScroll () {
-    document.querySelectorAll("[data-preserve-scroll]").forEach((element) => {
-      element.scrollLeft = scrollPositions[element.id];
+    document.querySelectorAll('[data-preserve-scroll]').forEach((element) => {
+      element.scrollLeft = window.scrollPositions[element.id]
     })
   }
 }

--- a/app/views/sessions/_filters.html.erb
+++ b/app/views/sessions/_filters.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (resource:) %>
 
-<div class="flex justify-between w-full mb-6">
-  <div class="flex items-center gap-2 overflow-x-scroll no-scrollbar">
+<div class="flex justify-between w-full mb-6" data-controller="preserve-scroll">
+  <div id="<%= resource %>_filters" class="flex items-center gap-2 overflow-x-scroll no-scrollbar" data-preserve-scroll>
     <%= link_to(
       'All dates',
       url_for([resource, session_filter_params.to_h]),


### PR DESCRIPTION
## Description
Preserve the horizontal scroll position on the date filters when selecting a pill. Check this [issue](https://github.com/hotwired/turbo/issues/37) for context.

## How has this been tested?

Please mark the tests that you ran to verify your changes. If difficult to test, consider providing instructions so reviewers can test.

- [x] Manual testing
- [ ] System tests
- [ ] Unit tests
- [ ] None

## Checklist

- [x] CI pipeline is passing
- [x] My code follows the conventions of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added seed data to the database (if applicable)

## Release tasks

Add any tasks that need to be done before/after the release of this feature.

## Screenshots/Loom

This section is relevant in case we want to share progress with the team, otherwise, it can be omitted.
