### PR TITLE
Add date to sessions hour titles

### DIFF
--- a/app/mailers/session_mailer.rb
+++ b/app/mailers/session_mailer.rb
@@ -4,7 +4,7 @@ class SessionMailer < ApplicationMailer
     @recipient = params[:recipient]
     @session = params[:record]
     @speakers = @session.speakers
-    @notification = params[:notification]
-    mail(to: @recipient.email, subject: default_i18n_subject)
+
+    mail(to: @recipient.email, subject: t("mailers.session_mailer.reminder.subject"))
   end
 end

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -69,7 +69,6 @@
         font-style: italic;
         font-weight: 900;
         line-height: 20px;
-        color: #CB0C1C;
       }
 
       .c-event-card__speaker-subtitle{
@@ -79,12 +78,14 @@
         line-height: 14px;
       }
 
-      .c-event-card__title{
+      .c-event-card__title, a{
         font-size: 20px;
         font-style: italic;
         font-weight: 900;
         line-height: 24px;
         margin-bottom: 16px;
+        color: #CB0C1C;
+        text-decoration: none;
       }
 
       .c-event-card__tags{

--- a/app/views/schedules/show.html.erb
+++ b/app/views/schedules/show.html.erb
@@ -10,11 +10,19 @@
 
     <div class="flex flex-col w-full h-full">
       <% if @sessions.present? %>
+        <% previous_day = nil %>
+
         <% @sessions.group_by(&:starts_at).each do |starts_at, sessions| %>
+          <% current_day = starts_at.to_date %>
+
           <div class="flex items-center">
-            <div class="pt-2 pb-4 text-2xl font-bold text-grey-800">
+            <div class="pt-2 pb-4 text-2xl font-bold text-grey-800 text-nowrap">
               <a id="<%= session_anchor(sessions.first) %>">
-                <%= starts_at.strftime("%H:%M") %>
+                <% if current_day != previous_day && params[:starts_at].blank? %>
+                  <%= starts_at.strftime("%b %d - %H:%M") %>
+                <% else %>
+                  <%= starts_at.strftime("%H:%M") %>
+                <% end %>
               </a>
             </div>
             <div class="w-full mx-2 mb-1 border-b"></div>
@@ -29,6 +37,8 @@
                   }
                 ) %>
           <% end %>
+
+          <% previous_day = current_day %>
         <% end %>
       <% elsif params[:starts_at].present? || session_filter_params.present? %>
         <div class="flex flex-col items-center justify-center w-full h-full">

--- a/app/views/session_mailer/reminder.html.erb
+++ b/app/views/session_mailer/reminder.html.erb
@@ -1,17 +1,21 @@
 <div class="u-w-full">
   <div class="container">
-    <h1 class="title">Your bookmarked session is <%= @notification.title.downcase %></h1>
+    <h1 class="title">Your bookmarked session is starting in 10 minutes.</h1>
     <div class="c-event-card">
       <div class="c-event-card__title">
-        <%= @session.title %>
+        <%= link_to @session.title, sessions_url %>
       </div>
 
       <% if @speakers.present? %>
         <% @speakers.each do |speaker| %>
           <div class="c-event-card__speaker">
-            <div class="c-event-card__speaker-img">
-              <%= speaker.name.split.take(2).map { |word| word[0].upcase }.join %>
-            </div>
+            <% if speaker.image&.attached? %>
+                <%= image_tag speaker.image, class: "c-event-card__speaker-img" %>
+            <% else %>
+              <div class="c-event-card__speaker-img">
+                <%= speaker.name.split.take(2).map { |word| word[0].upcase }.join %>
+              </div>
+            <% end %>
             <div>
               <div class="c-event-card__speaker-title"><%= speaker.name %></div>
               <div class="c-event-card__speaker-subtitle"><%= speaker.job_title %></div>
@@ -35,25 +39,20 @@
       <% end %>
 
       <div class="c-event-card__time">
-        <%# <div class="c-event-card__time-icon">
-        </div> %>
-        <div class="c-event-card__time-item">
-          <%= @session.starts_at.strftime("%A, %b %d") %>
+        <div class="c-event-card__time-icon">
+          <%= inline_svg_tag("icons/calendar.svg", size: "16") %>
         </div>
-      </div>
-
-      <div class="c-event-card__time">
-        <%# <div class="c-event-card__time-icon">
-        </div> %>
         <div class="c-event-card__time-item">
-          <%= @session.starts_at.strftime("%H:%M") %> - <%= @session.ends_at.strftime("%H:%M") %>
+          <%= @session.starts_at&.strftime("%b %d") %> -
+          <%= @session.starts_at&.strftime("%H:%M") %> to <%= @session.ends_at&.strftime("%H:%M") %>
         </div>
       </div>
 
       <% if @session.location.present? %>
         <div class="c-event-card__time">
-          <%# <div class="c-event-card__time-icon">
-          </div> %>
+          <div class="c-event-card__time-icon">
+            <%= inline_svg_tag("icons/location.svg", size: "16") %>
+          </div>
           <div class="c-event-card__time-item">
             <%= @session.location.name %>
           </div>
@@ -62,7 +61,9 @@
     </div>
   </div>
   <div class="c-footer">
-    <span class="u-text-center">RAILS WORLD 2024</span>
+    <span class="u-text-center">
+      <%= inline_svg_tag("main_logo.svg", width: "290") %>
+    </span>
   </div>
   <p class="c-unsubscribe-notifications">
     You are receiving this email because your notification settings are configured to receive communications. If you wish to stop receiving these emails, you can <a href="<%= notification_settings_url %>" class="c-unsubscribe-notifications__link" style="color: #CB0C1C">edit your settings</a>.

--- a/app/views/sessions/index.html.erb
+++ b/app/views/sessions/index.html.erb
@@ -10,16 +10,25 @@
 
     <div class="flex flex-col w-full h-full">
       <% if @sessions.present? %>
+        <% previous_day = nil %>
+
         <% @sessions.group_by(&:starts_at).each do |starts_at, sessions| %>
+          <% current_day = starts_at.to_date %>
+
           <div class="flex items-center">
-            <div class="pt-2 pb-4 text-2xl font-bold text-grey-800">
+            <div class="pt-2 pb-4 text-2xl font-bold text-grey-800 text-nowrap">
               <a id="<%= session_anchor(sessions.first) %>">
-                <%= starts_at.strftime("%H:%M") %>
+                <% if current_day != previous_day && params[:starts_at].blank? %>
+                  <%= starts_at.strftime("%b %d - %H:%M") %>
+                <% else %>
+                  <%= starts_at.strftime("%H:%M") %>
+                <% end %>
               </a>
             </div>
             <div class="w-full mx-2 mb-1 border-b"></div>
             <div class="mb-1 text-gray-400 text-nowrap"><%= pluralize(sessions.count, "Session") %></div>
           </div>
+
           <% sessions.each do |session| %>
             <%= render(
               partial: 'sessions/card',
@@ -29,6 +38,8 @@
               }
             ) %>
           <% end %>
+
+          <% previous_day = current_day %>
         <% end %>
       <% elsif params[:starts_at].present? || session_filter_params.present? %>
         <div class="flex flex-col items-center justify-center w-full h-full">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,6 +29,10 @@ en:
         notice: "Session was added to My Schedule"
       remove_user:
         notice: "Session was removed from My Schedule"
+  mailers:
+    session_mailer:
+      reminder:
+        subject: "Your bookmarked session is starting in 10 minutes."
   views:
     status_filters:
       past: "Past"


### PR DESCRIPTION
## Description
Display the month and day in the title for each group of sessions only when the date changes between groups. This applies only to the "All dates" filter.

## How has this been tested?

Please mark the tests that you ran to verify your changes. If difficult to test, consider providing instructions so reviewers can test.

- [x] Manual testing
- [ ] System tests
- [ ] Unit tests
- [ ] None

## Checklist

- [x] CI pipeline is passing
- [x] My code follows the conventions of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added seed data to the database (if applicable)

## Release tasks

Add any tasks that need to be done before/after the release of this feature.

## Screenshots/Loom

#### All dates
<img width="283" alt="image" src="https://github.com/user-attachments/assets/216b2a64-f990-483b-9e1c-3cba95b72e9e">

#### Specific date
<img width="309" alt="image" src="https://github.com/user-attachments/assets/4a00dca9-ddd1-435b-8fd4-3c84d6e5db8d">


