### PR TITLE
Improve back navigation button

### DIFF
--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -40,9 +40,11 @@ module NavigationHelper
   end
 
   def show_back_button?
-    current_page?(notification_settings_path) ||
-      resource_show_page?("speakers") ||
-      resource_show_page?("sessions")
+    request.referer.present? && (
+      current_page?(notification_settings_path) ||
+        resource_show_page?("speakers") ||
+        resource_show_page?("sessions")
+    )
   end
 
   def show_bookmark_button?(session)

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,10 +1,10 @@
 <% if show_back_button? %>
   <div class="relative flex items-center justify-center w-full py-2">
-    <%= link_to :back, class: "absolute left-0 flex items-center py-2" do %>
+    <%= link_to "javascript:history.back()", class: "absolute left-0 flex items-center py-2 pl-5" do %>
       <%= inline_svg_tag("icons/chevron_left.svg", size: "24", class: "fill-red") %>
       <span class="ml-1 text-lg italic font-black text-red">Back</span>
     <% end %>
-    <p class="text-lg font-bold"><%= back_title %></p>
+    <p class="text-lg font-medium"><%= back_title %></p>
   </div>
 <% end %>
 


### PR DESCRIPTION
## Description
- Use `javascript:history.back()` to navigate back in the user's browsing history, instead of returning to the last visited page.
- Only display the back button when users come from a page within the app.
- Style the back navigation bar to match the design.

## How has this been tested?

Please mark the tests that you ran to verify your changes. If difficult to test, consider providing instructions so reviewers can test.

- [x] Manual testing
- [ ] System tests
- [ ] Unit tests
- [ ] None

## Checklist

- [x] CI pipeline is passing
- [x] My code follows the conventions of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added seed data to the database (if applicable)

## Release tasks

Add any tasks that need to be done before/after the release of this feature.

## Screenshots/Loom

This section is relevant in case we want to share progress with the team, otherwise, it can be omitted.
