### PR TITLE
Prevent avatar from shrinking in Safari

### DIFF
--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -7,7 +7,7 @@
     <div class="z-10 flex flex-col items-start w-full max-w-screen-sm px-5 pt-6 pb-12">
       <div class="flex flex-row items-center">
         <% if @profile.image.attached? %>
-          <div class="flex flex-col items-center justify-center relative w-[120px] bg-cover bg-no-repeat bg-center h-[120px] rounded-full" style="background-image: url(<%= url_for(@profile.image) %>)">
+          <div class="flex flex-col items-center justify-center shrink-0 relative w-[120px] bg-cover bg-no-repeat bg-center h-[120px] rounded-full" style="background-image: url(<%= url_for(@profile.image) %>)">
           </div>
         <% else %>
           <div class="w-[120px] h-[120px] rounded-full bg-slate-300 p-5 flex flex-row items-center justify-center">


### PR DESCRIPTION
## Description

In Safari, the avatar shrinks into an oval shape.

## How has this been tested?

Please mark the tests that you ran to verify your changes. If difficult to test, consider providing instructions so reviewers can test.

- [x] Manual testing
- [ ] System tests
- [ ] Unit tests
- [ ] None

## Checklist

- [x] CI pipeline is passing
- [x] My code follows the conventions of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added seed data to the database (if applicable)

## Release tasks

No.

## Screenshots/Loom

<img width="410" alt="image" src="https://github.com/user-attachments/assets/af6037a6-238b-470a-a5db-20411f7c68c4">

<img width="390" alt="image" src="https://github.com/user-attachments/assets/859a9cc7-e538-4ec8-865e-47b467e4e69b">

