### PR TITLE
Fix - Cannot get a signed_id for a new record

### DIFF
--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -23,7 +23,7 @@
             accept:"image/*,image/apng,image/avif,image/gif,image/gif,image/jpeg,image/png,image/svg+xml",
             class: "text-white border-2 border-white bg-transparent rounded-sm hidden mb-6 focus:outline-none focus:outline-0 focus:ring-0 focus:border-2 focus:border-white active:border-2 active:border-white"
           ) %>
-          <% if @profile.image.present? %>
+          <% if @profile.image.present? && @profile.image.persisted? %>
             <%= image_tag @profile.image, data: {image_previewer_target: "hideOnLoad"}, class: "absolute object-cover h-full w-full" %>
           <% else %>
             <%= image_tag url_for("camera.svg"), data: {image_previewer_target: "hideOnLoad"} %>
@@ -35,7 +35,7 @@
           "icon_delete_photo.svg",
           data: {action: "click->image-previewer#removeImage", image_previewer_target: "deleteIcon" },
           class: "cursor-pointer absolute top-[5px] right-[5px] w-6 h-6",
-          style: @profile.image.present? ? "display:block;" : "display:none;"
+          style: @profile.image.present? && @profile.image.persisted? ? "display:block;" : "display:none;"
         ) %>
         <div class="hidden" data-image-previewer-target="onRemoveImageContainer"></div>
         <template data-image-previewer-target="onRemoveImagePlaceholderTemplate">


### PR DESCRIPTION
## Description
This PR solves [this error](https://appsignal.com/telos-labs-1/sites/6699677a94809a7074e5bef5/exceptions/incidents/94), by checking if the image is present and persists before attempting to display it after a validation error.

Ideally, uploading a valid image should not trigger this error just because other changes in the form submission didn't pass model validations, but this is an [open issue in Rails at the moment.](https://github.com/rails/rails/issues/50234)

### Other known issues
The following pre-existing but related issues are not fixed by this PR

1. Inputs shrink after model validation errors
2. Profile image preview disappears after model validation errors

## How has this been tested?

Please mark the tests that you ran to verify your changes. If difficult to test, consider providing instructions so reviewers can test.

- [ ] Manual testing
- [ ] System tests
- [ ] Unit tests
- [ ] None

### Manual testing
To reproduce the error and verify the fix

1. Go to profile edit
3. Add or update a profile image
4. Add or modify a social media link with an invalid URI scheme i.e `httpsd://github.com`
5. Submit form
6. If testing without the fix, it should error out with the 'Cannot get a signed_id for a new record` error. If the fix is in place, it should just show model validation errors referring to the social media url.

## Checklist

- [ ] CI pipeline is passing
- [ ] My code follows the conventions of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added seed data to the database (if applicable)

## Release tasks

None