### PR TITLE
refactor: remove check_box from profile web push field

### DIFF
--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -87,9 +87,8 @@
             <div class="flex flex-row items-center justify-between w-full p-4 bg-white">
               <%= form.label :web_push_notifications, "Web-push notifications", class: "grow font-medium text-slate-900 text-base cursor-pointer mr-2" %>
               <label>
-                <%= form.check_box :web_push_notifications, class: "sr-only peer",
+                <%= form.toggle_field :web_push_notifications, class: "sr-only peer",
                   data: {web_push_notifications_target: "enableNotifications"} %>
-                <div class="relative w-11 h-6 bg-grey-300 rounded-full peer dark:bg-grey-300 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-red"></div>
               </label>
             </div>
           </div>


### PR DESCRIPTION
## Description
The web push toggle on the profiles edit view is using check_box instead of the toggle_field form helper form application_form_builder.
We are updating the field by removing the check_box and div tag in the label tag and adding the toggle_field helper.

## How has this been tested?

Please mark the tests that you ran to verify your changes. If difficult to test, consider providing instructions so reviewers can test.

- [x] Manual testing
- [ ] System tests
- [ ] Unit tests
- [ ] None

## Checklist

- [x] CI pipeline is passing
- [x] My code follows the conventions of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added seed data to the database (if applicable)

## Release tasks

Add any tasks that need to be done before/after the release of this feature.

## Screenshots/Loom

This section is relevant in case we want to share progress with the team, otherwise, it can be omitted.
