### PR TITLE
unhide delete account button for web

### DIFF
--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -4,9 +4,9 @@
   <%= render partial: "layouts/primary_top_nav" %>
 <% end %>
 
-<div class="relative flex flex-col items-center justify-between flex-1 h-full bg-grey-50 pt-safe-area-header pb-safe-area-bottom-navbar">
+<div class="flex relative flex-col flex-1 justify-between items-center h-full bg-grey-50 pt-safe-area-header pb-safe-area-bottom-navbar">
   <div class="flex flex-col items-center bg-cover bg-bottom bg-no-repeat max-h-[430px] w-full" style="background-image: url(<%= asset_path 'background_design.svg' %>)">
-    <div class="z-10 flex flex-col items-start w-full max-w-screen-sm px-5 pt-6 pb-12">
+    <div class="flex z-10 flex-col items-start px-5 pt-6 pb-12 w-full max-w-screen-sm">
       <div class="flex flex-row items-center">
         <% if @profile.image.attached? %>
           <div class="flex flex-col items-center justify-center shrink-0 relative w-[120px] bg-cover bg-no-repeat bg-center h-[120px] rounded-full" style="background-image: url(<%= url_for(@profile.image) %>)">
@@ -26,7 +26,7 @@
       <% if @profile.bio.present? %>
         <p class="mt-6 text-base"><%= @profile.bio %></p>
       <% end %>
-      <div class="flex flex-row items-center justify-between w-full gap-4">
+      <div class="flex flex-row gap-4 justify-between items-center w-full">
         <%= link_to(
           @profile.github_url,
           target: "_blank",
@@ -68,7 +68,7 @@
   </div>
 
   <% if allowed_to?(:edit?, @profile, with: ProfilePolicy) %>
-    <div class="flex flex-col items-center w-full gap-6 p-4">
+    <div class="flex flex-col gap-6 items-center p-4 w-full">
       <% if @profile.is_public? %>
         <div class="p-6 bg-white rounded-2xl">
           <%= render inline: @profile.svg_qr_code(module_size: 4, svg_attributes: { "data-test-id": "qr_code" }) %>
@@ -87,7 +87,7 @@
       ) %>
       <%= button_to(
         "Delete Account", profile_path(@profile.uuid), method: :delete,
-        class: "text-red font-bold rounded-sm underline italic text-lg d-hotwire-native-inline hidden",
+        class: "text-red font-bold rounded-sm underline italic text-lg",
         data: {
           turbo_action: "clear_all",
           turbo_confirm: "Are you sure you want to delete your account? This action cannot be undone."


### PR DESCRIPTION
## Description

To remove the Android and iOS applications it is necessary for users to be able to delete their account, without the need to have the app installed.

Added the button to delete your web account in your profile view.

## How has this been tested?

Please mark the tests that you ran to verify your changes. If difficult to test, consider providing instructions so reviewers can test.

- [X] Manual testing
- [ ] System tests
- [ ] Unit tests
- [ ] None

## Checklist

- [X] CI pipeline is passing
- [X] My code follows the conventions of this project
- [X] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added seed data to the database (if applicable)
