### PR TITLE
Allow unauthenticated access to the account deletion page

### DIFF
--- a/app/controllers/account_deletions_controller.rb
+++ b/app/controllers/account_deletions_controller.rb
@@ -1,4 +1,6 @@
 class AccountDeletionsController < ApplicationController
+  allow_unauthenticated_access
+
   def show
   end
 end


### PR DESCRIPTION
## Description
Allow unauthenticated users to access the account deletion page so that they can see the steps to delete their account.

## How has this been tested?

Please mark the tests that you ran to verify your changes. If difficult to test, consider providing instructions so reviewers can test.

- [X] Manual testing
- [ ] System tests
- [ ] Unit tests
- [ ] None

## Checklist

- [X] CI pipeline is passing
- [X] My code follows the conventions of this project
- [X] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added seed data to the database (if applicable)


