### PR TITLE
Setup Rate Limit for Login and Password Reset

### DIFF
--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -3,7 +3,6 @@ class PasswordResetsController < ApplicationController
   rate_limit to: 3, 
     within: 1.minute, with: -> { 
       flash.now[:alert] = "Please try again later."
-      @user = User.new
       render :new, status: :too_many_requests
     }, 
     only: [:create],  by: -> { request.remote_ip }

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -2,7 +2,7 @@ class PasswordResetsController < ApplicationController
   allow_unauthenticated_access
   rate_limit to: 3, 
     within: 1.minute, with: -> { 
-      flash.now[:alert] = "Please try again later."
+      flash.now[:alert] = t("controllers.password_resets.update.rate_limit")
       render :new, status: :too_many_requests
     }, 
     only: [:create],  by: -> { request.remote_ip }

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -1,5 +1,8 @@
 class PasswordResetsController < ApplicationController
   allow_unauthenticated_access
+  rate_limit to: 3, 
+    within: 1.minute, with: -> { redirect_to new_password_reset_path, alert: "Please try again later.", status: :too_many_requests }, 
+    only: :create,  by: -> { request.remote_ip }
 
   before_action :set_user_by_token, only: [:edit, :update]
 

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -1,11 +1,11 @@
 class PasswordResetsController < ApplicationController
   allow_unauthenticated_access
-  rate_limit to: 3, 
-    within: 1.minute, with: -> { 
+  rate_limit to: 3,
+    within: 1.minute, with: -> {
       flash.now[:alert] = t("controllers.password_resets.update.rate_limit")
       render :new, status: :too_many_requests
-    }, 
-    only: [:create],  by: -> { request.remote_ip }
+    },
+    only: [:create], by: -> { request.remote_ip }
 
   before_action :set_user_by_token, only: [:edit, :update]
 

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -1,8 +1,12 @@
 class PasswordResetsController < ApplicationController
   allow_unauthenticated_access
   rate_limit to: 3, 
-    within: 1.minute, with: -> { redirect_to new_password_reset_path, alert: "Please try again later.", status: :too_many_requests }, 
-    only: :create,  by: -> { request.remote_ip }
+    within: 1.minute, with: -> { 
+      flash.now[:alert] = "Please try again later."
+      @user = User.new
+      render :new, status: :too_many_requests
+    }, 
+    only: [:create],  by: -> { request.remote_ip }
 
   before_action :set_user_by_token, only: [:edit, :update]
 

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -1,12 +1,12 @@
 class UserSessionsController < ApplicationController
   allow_unauthenticated_access only: [:new, :create]
-  rate_limit to: 3, 
-    within: 1.minute, with: -> { 
+  rate_limit to: 3,
+    within: 1.minute, with: -> {
       flash.now[:alert] = t("controllers.user_sessions.create.rate_limit")
       @user = User.new
       render :new, status: :too_many_requests
-    }, 
-    only: [:create],  by: -> { request.remote_ip }
+    },
+    only: [:create], by: -> { request.remote_ip }
 
   before_action :redirect_if_signed_in, only: [:new, :create]
 

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -1,8 +1,12 @@
 class UserSessionsController < ApplicationController
   allow_unauthenticated_access only: [:new, :create]
   rate_limit to: 3, 
-    within: 1.minute, with: -> { redirect_to new_user_session_path, alert: "Please try again later.", status: :too_many_requests }, 
-    only: :create,  by: -> { request.remote_ip }
+    within: 1.minute, with: -> { 
+      flash.now[:alert] = "Please try again later."
+      @user = User.new
+      render :new, status: :too_many_requests
+    }, 
+    only: [:create],  by: -> { request.remote_ip }
 
   before_action :redirect_if_signed_in, only: [:new, :create]
 

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -2,7 +2,7 @@ class UserSessionsController < ApplicationController
   allow_unauthenticated_access only: [:new, :create]
   rate_limit to: 3, 
     within: 1.minute, with: -> { 
-      flash.now[:alert] = "Please try again later."
+      flash.now[:alert] = t("controllers.user_sessions.create.rate_limit")
       @user = User.new
       render :new, status: :too_many_requests
     }, 

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -1,5 +1,8 @@
 class UserSessionsController < ApplicationController
   allow_unauthenticated_access only: [:new, :create]
+  rate_limit to: 3, 
+    within: 1.minute, with: -> { redirect_to new_user_session_path, alert: "Please try again later.", status: :too_many_requests }, 
+    only: :create,  by: -> { request.remote_ip }
 
   before_action :redirect_if_signed_in, only: [:new, :create]
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -26,7 +26,7 @@ Rails.application.configure do
   # Show full error reports and disable caching.
   config.consider_all_requests_local = true
   config.action_controller.perform_caching = false
-  config.cache_store = :null_store
+  config.cache_store = :memory_store
 
   # Render exception templates for rescuable exceptions and raise for other exceptions.
   config.action_dispatch.show_exceptions = :rescuable

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,6 +7,7 @@ en:
         notice: "Check your email to reset your password."
       update:
         notice: "Your password has been reset successfully. Please login."
+        rate_limit: "Please try again later."
       errors:
         invalid_token: "Invalid token, please try again."
     passwords:
@@ -28,6 +29,7 @@ en:
       create:
         notice: "Signed in successfully."
         alert: "Invalid email or password."
+        rate_limit: "Please try again later."
       destroy:
         notice: "You have been logged out."
     users:

--- a/spec/controllers/password_resets_controller_spec.rb
+++ b/spec/controllers/password_resets_controller_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe PasswordResetsController, type: :controller do
 
       it "allows up to 3 requests within 1 minute" do
         3.times do |i|
-          @request.env["REMOTE_ADDR"] = "192.168.1.100"
+          request.env["REMOTE_ADDR"] = "192.168.1.100"
           post :create, params: params
           expect(response).to redirect_to(post_submit_password_reset_path)
         end
@@ -55,14 +55,14 @@ RSpec.describe PasswordResetsController, type: :controller do
 
       it "blocks the 4th request" do
         3.times do
-          @request.env["REMOTE_ADDR"] = "192.168.1.100"
+          request.env["REMOTE_ADDR"] = "192.168.1.100"
           post :create, params: params
           expect(response).to redirect_to(post_submit_password_reset_path)
         end
 
-        @request.env["REMOTE_ADDR"] = "192.168.1.100"
+        request.env["REMOTE_ADDR"] = "192.168.1.100"
         post :create, params: params
-        
+
         expect(flash[:alert]).to eq("Please try again later.")
         expect(response).to have_http_status(:too_many_requests)
       end

--- a/spec/controllers/password_resets_controller_spec.rb
+++ b/spec/controllers/password_resets_controller_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe PasswordResetsController, type: :controller do
     context "with rate limit" do
       before do
         Rails.application.config.action_controller.perform_caching = true
+        Rails.cache.clear
       end
 
       after do

--- a/spec/controllers/password_resets_controller_spec.rb
+++ b/spec/controllers/password_resets_controller_spec.rb
@@ -28,6 +28,44 @@ RSpec.describe PasswordResetsController, type: :controller do
         expect(response).to redirect_to(post_submit_password_reset_path)
       end
     end
+
+    context "with rate limit" do
+      before do
+        Rails.application.config.action_controller.perform_caching = true
+      end
+
+      after do
+        Rails.cache.clear
+      end
+
+      let(:params) do
+        {
+          email: user.email
+        }
+      end
+
+      it "allows up to 3 requests within 1 minute" do
+        3.times do |i|
+          @request.env["REMOTE_ADDR"] = "192.168.1.100"
+          post :create, params: params
+          expect(response).to redirect_to(post_submit_password_reset_path)
+        end
+      end
+
+      it "blocks the 4th request" do
+        3.times do
+          @request.env["REMOTE_ADDR"] = "192.168.1.100"
+          post :create, params: params
+          expect(response).to redirect_to(post_submit_password_reset_path)
+        end
+
+        @request.env["REMOTE_ADDR"] = "192.168.1.100"
+        post :create, params: params
+        
+        expect(flash[:alert]).to eq("Please try again later.")
+        expect(response).to have_http_status(:too_many_requests)
+      end
+    end
   end
 
   describe "GET #edit" do

--- a/spec/controllers/user_sessions_controller_spec.rb
+++ b/spec/controllers/user_sessions_controller_spec.rb
@@ -50,6 +50,7 @@ RSpec.describe UserSessionsController, type: :controller do
     context "with rate limit" do
       before do
         Rails.application.config.action_controller.perform_caching = true
+        Rails.cache.clear
       end
 
       after do
@@ -66,14 +67,12 @@ RSpec.describe UserSessionsController, type: :controller do
       end
 
       it "rate limits a request after 3 attempts under a minute" do
-        3.times do |_|
+        3.times do
           expect { post :create, params: params }.not_to change(User, :count)
-          expect(response).to redirect_to(new_user_session_path)
+          expect(response).to have_http_status(:redirect)
         end
 
         post :create, params: params
-
-        expect { post :create, params: params }.not_to change(User, :count)
         expect(response).to have_http_status(:too_many_requests)
       end
     end

--- a/spec/controllers/user_sessions_controller_spec.rb
+++ b/spec/controllers/user_sessions_controller_spec.rb
@@ -46,5 +46,36 @@ RSpec.describe UserSessionsController, type: :controller do
         expect(response).to redirect_to(new_user_session_path)
       end
     end
+
+    context "with rate limit" do
+      before do
+        Rails.application.config.action_controller.perform_caching = true
+      end
+
+      after do
+        Rails.cache.clear
+      end
+
+      let(:params) do
+        {
+          user: {
+            email: user.email,
+            password: "invalid_password"
+          }
+        }
+      end
+
+      it "rate limits a request after 3 attempts under a minute" do
+        3.times do |_|
+          expect { post :create, params: params }.not_to change(User, :count)
+          expect(response).to redirect_to(new_user_session_path)
+        end
+
+        post :create, params: params
+
+        expect { post :create, params: params }.not_to change(User, :count)
+        expect(response).to have_http_status(:too_many_requests)
+      end
+    end
   end
 end

--- a/spec/support/authentication_helper.rb
+++ b/spec/support/authentication_helper.rb
@@ -1,6 +1,8 @@
 module AuthenticationHelper
   def sign_in(user, password = "password2024")
     if respond_to?(:visit) # System specs
+      Rails.cache.clear if Rails.cache.respond_to?(:clear)
+
       visit new_user_session_path
       find_dti("email_field").set(user.email)
       find_dti("password_field").set(password)


### PR DESCRIPTION
## Description

This PR adds rate limiting to the user login and password reset routes using built in rails limiting. It returns a 429 if a user attempts too many incorrect login attempts along with resetting a password.

https://github.com/TelosLabs/rails-world/issues/95

I added `memory_store` to the `test` initializer because it wasn't allow me to set the memory store in the before block.


## How has this been tested?


To test appropriately go to `new_registration/new` and try and sign in three times under a minute you should see an error you need to enable caching locally using `rails dev:cache`

<img width="518" height="987" alt="Screenshot 2025-09-04 at 2 50 08 PM" src="https://github.com/user-attachments/assets/d3368995-0350-407f-b303-0987bd40ac4b" />
<img width="742" height="766" alt="Screenshot 2025-09-04 at 2 47 14 PM" src="https://github.com/user-attachments/assets/fa967cb0-83b9-41b5-a13d-94211898b9c2" />



- [X ] Manual testing
- [ ] System tests
- [ X] Unit tests
- [ ] None

## Checklist

- [X ] CI pipeline is passing
- X[ ] My code follows the conventions of this project
- [X ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added seed data to the database (if applicable)

## Release tasks

Add any tasks that need to be done before/after the release of this feature.

## Screenshots/Loom

This section is relevant in case we want to share progress with the team, otherwise, it can be omitted.
